### PR TITLE
gulp etc. should be in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"bugs": {
 		"url": "https://github.com/NextStepWebs/codemirror-spell-checker/issues"
 	},
-	"dependencies": {
+	"devDependencies": {
 		"gulp": "*",
 		"gulp-minify-css": "*",
 		"gulp-uglify": "*",


### PR DESCRIPTION
Mirroring the change in https://github.com/NextStepWebs/simplemde-markdown-editor/commit/28d97ab64459b7223f5a51f29c37444f28364f9b, gulp etc can also be made devDependencies in this repo.
