### PR TITLE
gulp etc. should be in devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"bugs": {
 		"url": "https://github.com/NextStepWebs/codemirror-spell-checker/issues"
 	},
-	"dependencies": {
+	"devDependencies": {
 		"gulp": "*",
 		"gulp-minify-css": "*",
 		"gulp-uglify": "*",


### PR DESCRIPTION
Mirroring the change in NextStepWebs/simplemde-markdown-editor@28d97ab, gulp etc can also be made devDependencies in this repo.
This time against the development branch :)
