### PR TITLE
Fix module references

### DIFF
--- a/src/js/spell-checker.js
+++ b/src/js/spell-checker.js
@@ -1,4 +1,6 @@
 // Initialize data globally to reduce memory consumption
+var CodeMirror = require("codemirror");
+var Typo = require("./typo");
 var num_loaded = 0;
 var aff_loading = false;
 var dic_loading = false;

--- a/src/js/typo.js
+++ b/src/js/typo.js
@@ -764,3 +764,5 @@ Typo.prototype = {
 		return correct(word);
 	}
 };
+
+module.exports = Typo;


### PR DESCRIPTION
Fix the reference to CodeMirror by instead of trying to use a global,
require the module. Also fix the usage of Typo, using the same
principles. This fixes #14 for good.
