### PR TITLE
Add bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,27 @@
+{
+  "name": "codemirror-spell-checker",
+  "description": "Dead-simple spell checking in CodeMirror.",
+  "main": "gulpfile.js",
+  "authors": [
+    "Wes Cossick <http://www.WesCossick.com>"
+  ],
+  "license": "MIT",
+  "keywords": [
+    "codemirror",
+    "code",
+    "mirror",
+    "spell",
+    "checker",
+    "checking",
+    "spellchecker",
+    "javascript"
+  ],
+  "homepage": "https://github.com/NextStepWebs/codemirror-spell-checker",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
It would be awesome to be able to install this package from bower, however it requires a valid `bower.json` in the project directory for that to work. I've generated one that I hope will be sufficient for this.

Should this pull request get accepted then it would be helpful to do `bower register codemirror-spell-checker https://github.com/NextStepWebs/codemirror-spell-checker.git` though I would be happy to do this myself.
