### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Via [bower](https://www.bower.io).
 bower install codemirror-spell-checker --save
 ```
 
-Via [jsDelivr](https://www.jsdelivr.com/projects/codemirror.spell-checker). *Please note, jsDelivr may take a few days to update to the latest release.*
+Via [jsDelivr](https://www.jsdelivr.com/projects/codemirror.spell-checker).
 
 ```HTML
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/codemirror.spell-checker/latest/spell-checker.min.css">
-<script src="https://cdn.jsdelivr.net/codemirror.spell-checker/latest/spell-checker.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror-spell-checker@latest/dist/spell-checker.min.css">
+<script src="https://cdn.jsdelivr.net/npm/codemirror-spell-checker@latest/dist/spell-checker.min.js"></script>
 ```
 
 ## Quick start

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "homepage": "https://github.com/NextStepWebs/codemirror-spell-checker",
   "main": "./src/js/spell-checker.js",
+  "jsdelivr": "dist/spell-checker.min.js",
   "license": "MIT",
   "company": "Next Step Webs, Inc.",
   "author": {


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version. 

You can find links for all files at https://www.jsdelivr.com/package/npm/codemirror-spell-checker.

I also set the default file to `dist/spellchecker.min.js`.

Feel free to ping me if you have any questions regarding this change.